### PR TITLE
Improve handling of undefined timed word actions

### DIFF
--- a/src/signature.hh
+++ b/src/signature.hh
@@ -37,6 +37,9 @@ public:
   std::size_t getId(const std::string &key) const {
     return idMap.at(key);
   }
+  bool isDefined(const std::string &key) const {
+    return idMap.find(key) != idMap.end();
+  }
 private:
   std::unordered_map<std::string, std::size_t> idMap;
   std::unordered_map<std::string, std::size_t> stringSizeMap;

--- a/src/timed_word_parser.hh
+++ b/src/timed_word_parser.hh
@@ -26,31 +26,39 @@ public:
     @retval false If the parse failed
    */
   bool parse(TimedWordEvent<Number, TimeStamp> &event) {
-    if (is.eof()) {
-      return false;
+    while (true) {
+      if (is.eof()) {
+        return false;
+      }
+      std::string action;
+      is >> action;
+      if (action.empty()) {
+        return false;
+      }
+      if (!sig.isDefined(action)) {
+        std::string skipped;
+        std::getline(is, skipped);
+        std::cerr << "Undefined action: " << action << std::endl;
+        continue;
+      }
+      const std::size_t stringSize = sig.getStringSize(action);
+      const std::size_t numberSize = sig.getNumberSize(action);
+      event.actionId = sig.getId(action);
+      event.strings.resize(stringSize);
+      for (std::size_t i = 0; i < stringSize; i++) {
+        std::string str;
+        is >> str;
+        event.strings[i] = std::move(str);
+      }
+      event.numbers.resize(numberSize);
+      for (std::size_t i = 0; i < numberSize; i++) {
+        Number num;
+        is >> num;
+        event.numbers[i] = std::move(num);
+      }
+      is >> event.timestamp;
+      return true;
     }
-    std::string action;
-    is >> action;
-    if (action.empty()) {
-      return false;
-    }
-    const std::size_t stringSize = sig.getStringSize(action);
-    const std::size_t numberSize = sig.getNumberSize(action);
-    event.actionId = sig.getId(action);
-    event.strings.resize(stringSize);
-    for (std::size_t i = 0; i < stringSize; i++) {
-      std::string str;
-      is >> str;
-      event.strings[i] = std::move(str);
-    }
-    event.numbers.resize(numberSize);
-    for (std::size_t i = 0; i < numberSize; i++) {
-      Number num;
-      is >> num;
-      event.numbers[i] = std::move(num);
-    }
-    is >> event.timestamp;
-    return true;
   }
 private:
   std::istream &is;

--- a/test/timed_word_parser_test.cc
+++ b/test/timed_word_parser_test.cc
@@ -62,4 +62,24 @@ BOOST_FIXTURE_TEST_CASE(withdrawWithoutLF, WithdrawWordFixture)
   execute();
 }
 
+BOOST_AUTO_TEST_CASE(skipUndefinedAction)
+{
+  std::stringstream sigStream;
+  std::stringstream wordStream;
+  sigStream << "withdraw\t1\t1" << "\n";
+  wordStream << "deposit\tAlice\t1000\t10" << "\n"
+             << "withdraw\tBob\t300\t20";
+
+  Signature sig(sigStream);
+  TimedWordParser<int> parser {wordStream, sig};
+
+  TimedWordEvent<int> event;
+
+  BOOST_TEST(parser.parse(event));
+  BOOST_CHECK_EQUAL(event.strings.front(), "Bob");
+  BOOST_CHECK_EQUAL(event.numbers.front(), 300);
+  BOOST_CHECK_EQUAL(event.timestamp, 20);
+  BOOST_TEST(!parser.parse(event));
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary
- detect whether an action is defined in the signature
- skip undefined actions while parsing timed words and notify via `stderr`
- test parsing timed words containing an undefined action

## Testing
- `cmake ..`
- `cmake --build . --target unit_test`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68574cd39f60833288cb0127be2dcae5